### PR TITLE
docs: fadeout webpack

### DIFF
--- a/radar/2023-09-01/webpack.md
+++ b/radar/2023-09-01/webpack.md
@@ -1,0 +1,9 @@
+---
+title:      "Webpack"
+ring:       adopt
+quadrant:   tools
+tags:       [frontend, coding]
+featured:   false
+---
+
+Webpack still is one of, if not even the most used bundler by now. The team behind is continuously fixing bugs and adding new features that are released in major version updates. Even if there were new bundlers coming up in recent years, we still can recommend using Webpack.


### PR DESCRIPTION
Fading out webpack as we no longer see a necissity to highlight it. Additionally added some text that makes clear that we keep recommending it.