### PR TITLE
docs: fadeout flux and move to on hold

### DIFF
--- a/radar/2023-09-01/flux.md
+++ b/radar/2023-09-01/flux.md
@@ -1,0 +1,17 @@
+---
+title:      "Flux"
+ring:       hold
+quadrant:   methods-and-patterns
+tags:       [frontend]
+featured:   false
+---
+
+In the early days of [React](/languages-and-frameworks/react.html), [Flux](https://github.com/facebookarchive/flux) was
+introduced by Facebook as an architectural pattern for managing global state.
+Later, it was also developed as a library along with others from the community.
+
+There are now a number of libraries that offer the Flux pattern or similar approaches to state management.
+Among them are framework-agnostic solutions like [Redux](/languages-and-frameworks/redux.html) or [MobX](https://mobx.js.org/README.html),
+but also framework-specific ones like [Pinia](https://pinia.vuejs.org/) (Vue), [Zustand](https://docs.pmnd.rs/zustand) (React) and many others.
+
+One of the most popular solutions so far is Redux, which is why we use it in several projects.

--- a/radar/2023-09-01/state-management-pattern.md
+++ b/radar/2023-09-01/state-management-pattern.md
@@ -1,0 +1,16 @@
+---
+title:      "State Management Pattern"
+ring:       adopt
+quadrant:   methods-and-patterns
+tags:       [architecture, coding]
+---
+
+State Management is a design pattern with the goal of properly sharing state data across components and separating domain representation from state management.
+This pattern is applied by many popular web frameworks such as [Vuex](/languages-and-frameworks/vuex.html) or [Redux](/languages-and-frameworks/redux.html).
+
+Especially in [reactive](/methods-and-patterns/reactive-programming.html) systems, this pattern helps to solve the task of maintaining decoupled, stateless components with immutable data.
+The ways of implementing state management differs and depends on the specific requirements of the application at hand.
+
+For distributed backend systems one might want to utilize [Akka's](/languages-and-frameworks/akka.html) cluster sharding module to elastically manage domain object states.
+
+We use the various state management patterns across most [Vue](/languages-and-frameworks/vue.html) and [React](/languages-and-frameworks/react.html) projects that warrant them.


### PR DESCRIPTION
Fading out Flux and putting it on hold as there are more sophisticated alternatives to handle state. Also adapting State Management Pattern to reflect putting Flux on hold.